### PR TITLE
migrate off deprecated API in EditorCustomElementRenderer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ dependencies {
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
-    version '2018.2'
+    version '2018.3'
     plugins 'Kotlin', 'android'
     updateSinceUntilBuild false
 }

--- a/src/main/kotlin/net/aquadc/mike/plugin/interfaces/UpcastHints.kt
+++ b/src/main/kotlin/net/aquadc/mike/plugin/interfaces/UpcastHints.kt
@@ -9,6 +9,7 @@ import com.intellij.codeInsight.hints.ModificationStampHolder
 import com.intellij.lang.jvm.types.JvmReferenceType
 import com.intellij.openapi.components.AbstractProjectComponent
 import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.Inlay
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Key
 import com.intellij.openapi.vfs.VirtualFile
@@ -175,7 +176,7 @@ class UpcastHintsPass(
     override fun createRenderer(text: String): HintRenderer = MethodChainHintRenderer(text)
 
     private class MethodChainHintRenderer(text: String) : HintRenderer(text) {
-        override fun getContextMenuGroupId() = "UpcastHintsContextMenu"
+        override fun getContextMenuGroupId(inlay: Inlay<*>) = "UpcastHintsContextMenu"
     }
 
     companion object {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -48,7 +48,7 @@
     ]]></description>
 
     <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description -->
-    <idea-version since-build="182.0"/>
+    <idea-version since-build="183.2940.10"/>
 
     <extensions defaultExtensionNs="com.intellij">
 


### PR DESCRIPTION
We're going to remove deprecated members of EditorCustomElementRenderer in 2020.1 IDE versions. This fix replaces usage of deprecated member with non-deprecated alternative.